### PR TITLE
解决网络和本地视频加载过慢的问题

### DIFF
--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdCache.h
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdCache.h
@@ -72,6 +72,15 @@ typedef void(^SaveCompletionBlock)(BOOL result , NSURL * URL);
 +(BOOL)checkVideoInCacheWithURL:(NSURL *)url;
 
 /**
+ *  检查是否已缓存该视频(仅限于本地视频读取使用)
+ *
+ *  @param videoFileName 本地视频文件名称
+ *
+ *  @return BOOL
+ */
++(BOOL)checkVideoInCacheWithFileName:(NSString *)videoFileName;
+
+/**
  *  获取缓存视频路径
  *
  *  @param url 视频链接url
@@ -102,6 +111,11 @@ typedef void(^SaveCompletionBlock)(BOOL result , NSURL * URL);
  *  生成视频路径 for url
  */
 +(NSString *)videoPathWithURL:(NSURL *)url;
+
+/**
+ *  生成视频路径 for videoFileName(仅限于本地视频读取使用)
+ */
++(NSString *)videoPathWithFileName:(NSString *)videoFileName;
 
 #pragma mark - url缓存
 /**

--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdCache.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdCache.m
@@ -84,12 +84,22 @@
     return [[self xhLaunchAdCachePath] stringByAppendingPathComponent:[self videoNameWithURL:url]];
 }
 
++(NSString *)videoPathWithFileName:(NSString *)videoFileName{
+    if(videoFileName.length<=0) return nil;
+    return [[self xhLaunchAdCachePath] stringByAppendingPathComponent:[self videoNameWithURL:[NSURL URLWithString:videoFileName]]];
+}
+
+
 +(BOOL)checkImageInCacheWithURL:(NSURL *)url{
     return [[NSFileManager defaultManager] fileExistsAtPath:[self imagePathWithURL:url]];
 }
 
 +(BOOL)checkVideoInCacheWithURL:(NSURL *)url{
     return [[NSFileManager defaultManager] fileExistsAtPath:[self videoPathWithURL:url]];
+}
+
++(BOOL)checkVideoInCacheWithFileName:(NSString *)videoFileName{
+    return [[NSFileManager defaultManager] fileExistsAtPath:[self videoPathWithFileName:videoFileName]];
 }
 
 +(void)checkDirectory:(NSString *)path {

--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdView.h
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdView.h
@@ -35,9 +35,10 @@
 @interface XHLaunchAdVideoView : UIView
 
 @property (nonatomic, copy) void(^click)(CGPoint point);
-@property (strong, nonatomic) MPMoviePlayerController *videoPlayer;
-@property(nonatomic,assign)MPMovieScalingMode videoScalingMode;
+@property (nonatomic, strong) AVPlayerViewController *videoPlayer;
+@property (nonatomic, assign) MPMovieScalingMode videoScalingMode;
 @property (nonatomic, assign) BOOL videoCycleOnce;
+@property (nonatomic, strong) NSURL *contentURL;
 
 -(void)stopVideoPlayer;
 

--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdView.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdView.m
@@ -66,26 +66,44 @@
 
 -(void)setVideoScalingMode:(MPMovieScalingMode)videoScalingMode{
     _videoScalingMode = videoScalingMode;
-    _videoPlayer.scalingMode  = videoScalingMode;
+    switch (_videoScalingMode) {
+        case MPMovieScalingModeNone:{
+            _videoPlayer.videoGravity = AVLayerVideoGravityResizeAspect;
+        }
+            break;
+        case MPMovieScalingModeAspectFit:{
+            _videoPlayer.videoGravity = AVLayerVideoGravityResizeAspect;
+        }
+            break;
+        case MPMovieScalingModeAspectFill:{
+            _videoPlayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
+        }
+            break;
+        case MPMovieScalingModeFill:{
+            _videoPlayer.videoGravity = AVLayerVideoGravityResize;
+        }
+            break;
+        default:
+            break;
+    }
 }
 
--(MPMoviePlayerController *)videoPlayer{
+-(AVPlayerViewController *)videoPlayer{
     if(_videoPlayer==nil){
-        _videoPlayer = [[MPMoviePlayerController alloc] init];
-        _videoPlayer.shouldAutoplay = YES;
-        [_videoPlayer setControlStyle:MPMovieControlStyleNone];
-        _videoPlayer.repeatMode = MPMovieRepeatModeOne;
-        _videoPlayer.scalingMode  = MPMovieScalingModeAspectFill;
+        _videoPlayer = [[AVPlayerViewController alloc] init];
+        _videoPlayer.showsPlaybackControls = NO;
+        _videoPlayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
         _videoPlayer.view.frame = [UIScreen mainScreen].bounds;
-        _videoPlayer.backgroundView.backgroundColor = [UIColor clearColor];
         _videoPlayer.view.backgroundColor = [UIColor clearColor];
+        //注册通知控制是否循环播放
+        [[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(runLoopTheMovie:) name:AVPlayerItemDidPlayToEndTimeNotification object:nil];
     }
     return _videoPlayer;
 }
 
 -(void)stopVideoPlayer{
     if(_videoPlayer==nil) return;
-    [_videoPlayer stop];
+    [_videoPlayer.player pause];
     [_videoPlayer.view removeFromSuperview];
     _videoPlayer = nil;
 }
@@ -96,13 +114,24 @@
     _videoPlayer.view.frame = self.frame;
 }
 
--(void)setVideoCycleOnce:(BOOL)videoCycleOnce{
-    _videoCycleOnce = videoCycleOnce;
-    if(videoCycleOnce){
-         _videoPlayer.repeatMode = MPMovieRepeatModeNone;//不重复播放,播放一次
-    }else{
-         _videoPlayer.repeatMode = MPMovieRepeatModeOne;//循环播放
+- (void)setContentURL:(NSURL *)contentURL {
+    _contentURL = contentURL;
+    AVAsset *movieAsset = [AVURLAsset URLAssetWithURL:contentURL options:nil];
+    AVPlayerItem * playerItem = [AVPlayerItem playerItemWithAsset:movieAsset];
+    self.videoPlayer.player = [AVPlayer playerWithPlayerItem:playerItem];
+}
+
+#pragma mark - notification
+- (void)runLoopTheMovie:(NSNotification *)notification{
+    if(_videoCycleOnce){
+        //注册的通知  可以自动把 AVPlayerItem 对象传过来，只要接收一下就OK
+        [(AVPlayerItem *)[notification object] seekToTime:kCMTimeZero];
+        [self.videoPlayer.player play];
     }
+}
+
+-(void)removeNotification{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 @end


### PR DESCRIPTION
替换开屏视频播放控制器为 `AVPlayerViewController` 真机实测可以解决加载视频过慢的问题,但有两个风险点需要注意:

您框架的支持的最低版本需要从 7.0 提升到 8.0 ,因为 `AVPlayerViewController` 需要 iOS 8.0 以上的版本才可以运行.
设置 `MPMovieScalingMode` 的 `MPMovieScalingModeNone` 这个枚举值会无效.(PS:我关注到你在 `XHLaunchVideoAdConfiguration` 这个配置类里面暴露了一个 `MPMovieScalingMode` 类型的枚举作为视频缩放模式选项,通过对这个枚举进行转义可以兼容原来的设置,避免 API 的变动对其他使用者造成影响.但 `AVPlayerViewController` 并没有无缩放模式,所以如果设置 `MPMovieScalingModeNone` 这个枚举值的话,目前会把他当做 `MPMovieScalingModeAspectFit` 来处理).

tips: 如何复现加载视频过慢这个场景
在 `AppDelegate.m` 的 `- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions;` 最后加入以下代码:
`dispatch_async(dispatch_get_main_queue(), ^{
// 模拟异步阻塞2秒
sleep(2.f);
});`

我在测试中注意到在主线程阻塞时加载本地视频要比加载网络视频的速度慢的多,通过排查我发现问题出现在 `XHLaunchAd.m` 343行,在 Bundle 中搜索资源是一个比较耗时的 I/O 操作,在主线程阻塞时运行会把大量的时间都浪费在寻找路径这一步.
我想到一个优化方案, 在第一次运行的时候把 Bundle 中对应的视频资源拷贝一份到你的视频缓存文件夹中,这样下次可以直接根据文件名称生成文件路径, 简单的核查这个文件是否存在即可 ,省略了在 Bundle 中查找文件这一步耗时操作.
同时,我发现优化了以上问题之后本地视频的加载仍然有卡顿,与播放网络视频有差异,我排查代码发现以下的方法受到主线程阻塞的影响,于是我决定使用`dispatch_after` 这个语句利用 GCD 规避当前 RunLoop 的阻塞. 
`-(void)setupVideoAdForConfiguration:(XHLaunchVideoAdConfiguration *)configuration;`


经过以上的优化,目前在主线程阻塞的情况下本地和网络视频播放的效果是可以令人接收的.
