### PR TITLE
针对对iOS不支持的视频编码格式增加播放失败通知

### DIFF
--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdConst.h
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdConst.h
@@ -75,7 +75,8 @@ UIKIT_EXTERN NSString *const XHLaunchAdDetailPageShowFinishNotification;
 UIKIT_EXTERN NSString *const XHLaunchAdGIFImageCycleOnceFinishNotification;
 /** videoCycleOnce = YES(视频不循环时) ,video播放完成通知 */
 UIKIT_EXTERN NSString *const XHLaunchAdVideoCycleOnceFinishNotification;
-
+/** 视频播放失败通知 */
+UIKIT_EXTERN NSString *const XHLaunchAdVideoPlayFailedNotification;
 UIKIT_EXTERN BOOL XHLaunchAdPrefersHomeIndicatorAutoHidden;
 
 

--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdConst.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdConst.m
@@ -16,5 +16,7 @@ NSString *const XHLaunchAdDetailPageWillShowNotification = @"XHLaunchAdDetailPag
 NSString *const XHLaunchAdDetailPageShowFinishNotification = @"XHLaunchAdDetailPageShowFinishNotification";
 NSString *const XHLaunchAdGIFImageCycleOnceFinishNotification = @"XHLaunchAdGIFImageCycleOnceFinishNotification";
 NSString *const XHLaunchAdVideoCycleOnceFinishNotification = @"XHLaunchAdVideoCycleOnceFinishNotification";
+NSString *const XHLaunchAdVideoPlayFailedNotification = @"XHLaunchAdVideoPlayFailedNotification";
 
 BOOL XHLaunchAdPrefersHomeIndicatorAutoHidden = NO;
+


### PR DESCRIPTION
后台如果返回的url视频是H.263格式的，视频下载下来后会播放不了，会卡在启动页几秒钟，增加播放失败通知