### PR TITLE
fix #178 解决LaunchScreen截图时，SafeArea为0不正确导致子视图下移的问题

### DIFF
--- a/XHLaunchAd/XHLaunchAd/XHLaunchImageView.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchImageView.m
@@ -58,6 +58,7 @@
         UIWindow *containerWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
         [containerWindow addSubview:view];
         view.frame = containerWindow.bounds;
+        [containerWindow layoutIfNeeded];
         
         UIImage *image = [self imageFromView:view];
         return image;

--- a/XHLaunchAd/XHLaunchAd/XHLaunchImageView.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchImageView.m
@@ -55,7 +55,10 @@
     UIViewController *LaunchScreenSb = [[UIStoryboard storyboardWithName:UILaunchStoryboardName bundle:nil] instantiateInitialViewController];
     if(LaunchScreenSb){
         UIView * view = LaunchScreenSb.view;
-        view.frame = [UIScreen mainScreen].bounds;
+        UIWindow *containerWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+        [containerWindow addSubview:view];
+        view.frame = containerWindow.bounds;
+        
         UIImage *image = [self imageFromView:view];
         return image;
     }


### PR DESCRIPTION
从Launch Screen.storyboard实例化的LaunchScreenSb，在没有加入到UIWindow时，LaunchScreenSb.view的safeAreaInsets为0，所以就会导致使用SafeArea设置约束的子视图在XHLaunchAd截图时位置出现偏差。解决办法就是加入到一个UIWindow，safeAreaInsets就会从UIWindows传递到LaunchScreenSb.view，此时的LaunchScreenSb.view的safeAreaInsets就不会为0，截图跟App启动时的显示一模一样。