### PR TITLE
解决LaunchScreen子视图使用Safe Area布局后，在截图时的子视图位置偏移的问题

### DIFF
--- a/XHLaunchAd/XHLaunchAd/XHLaunchImageView.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchImageView.m
@@ -73,8 +73,7 @@
     CGSize size = view.bounds.size;
     //参数1:表示区域大小 参数2:如果需要显示半透明效果,需要传NO,否则传YES 参数3:屏幕密度
     UIGraphicsBeginImageContextWithOptions(size, NO, [UIScreen mainScreen].scale);
-    // https://github.com/CoderZhuXH/XHLaunchAd/issues/178 参考@hucong730代码，解决刘海屏机型Safe Area不生效的问题
-    [view drawViewHierarchyInRect:view.bounds afterScreenUpdates:YES];
+    [view.layer renderInContext:UIGraphicsGetCurrentContext()];
     
     UIImage*image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();

--- a/XHLaunchAd/XHLaunchAd/XHLaunchImageView.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchImageView.m
@@ -55,7 +55,13 @@
     UIViewController *LaunchScreenSb = [[UIStoryboard storyboardWithName:UILaunchStoryboardName bundle:nil] instantiateInitialViewController];
     if(LaunchScreenSb){
         UIView * view = LaunchScreenSb.view;
-        view.frame = [UIScreen mainScreen].bounds;
+        
+        // 加入到UIWindow后，LaunchScreenSb.view的safeAreaInsets在刘海屏机型才正常。
+        UIWindow *containerWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+        view.frame = containerWindow.bounds;
+        [containerWindow addSubview:view];
+        [containerWindow layoutIfNeeded];
+        
         UIImage *image = [self imageFromView:view];
         return image;
     }
@@ -67,7 +73,9 @@
     CGSize size = view.bounds.size;
     //参数1:表示区域大小 参数2:如果需要显示半透明效果,需要传NO,否则传YES 参数3:屏幕密度
     UIGraphicsBeginImageContextWithOptions(size, NO, [UIScreen mainScreen].scale);
-    [view.layer renderInContext:UIGraphicsGetCurrentContext()];
+    // https://github.com/CoderZhuXH/XHLaunchAd/issues/178 参考@hucong730代码，解决刘海屏机型Safe Area不生效的问题
+    [view drawViewHierarchyInRect:view.bounds afterScreenUpdates:YES];
+    
     UIImage*image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     return image;


### PR DESCRIPTION
在刘海屏机型，如果LaunchScreen的子视图使用Safe Area布局后，在截图时，会出现子视图偏移的问题，原因是在截图时LaunchScreenSb.view的safeAreaInsets为0。
解决办法：
截图前添加到UIWindow，UIWindow会把safeAreaInsets传递给LaunchScreenSb.view。