### PR TITLE
规范第三方库头文件引入

### DIFF
--- a/XHLaunchAd/XHLaunchAd/XHLaunchAd.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAd.m
@@ -11,8 +11,13 @@
 #import "XHLaunchAdImageView+XHLaunchAdCache.h"
 #import "XHLaunchAdDownloader.h"
 #import "XHLaunchAdCache.h"
-#import "FLAnimatedImage.h"
 #import "XHLaunchAdController.h"
+
+#if __has_include(<FLAnimatedImage/FLAnimatedImage.h>)
+    #import <FLAnimatedImage/FLAnimatedImage.h>
+#else
+    #import "FLAnimatedImage.h"
+#endif
 
 typedef NS_ENUM(NSInteger, XHLaunchAdType) {
     XHLaunchAdTypeImage,

--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdDownloader.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdDownloader.m
@@ -8,8 +8,13 @@
 
 #import "XHLaunchAdDownloader.h"
 #import "XHLaunchAdCache.h"
-#import "FLAnimatedImage.h"
 #import "XHLaunchAdConst.h"
+
+#if __has_include(<FLAnimatedImage/FLAnimatedImage.h>)
+    #import <FLAnimatedImage/FLAnimatedImage.h>
+#else
+    #import "FLAnimatedImage.h"
+#endif
 
 #pragma mark - XHLaunchAdDownload
 

--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdImageView+XHLaunchAdCache.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdImageView+XHLaunchAdCache.m
@@ -7,8 +7,13 @@
 //  代码地址:https://github.com/CoderZhuXH/XHLaunchAd
 
 #import "XHLaunchAdImageView+XHLaunchAdCache.h"
-#import "FLAnimatedImage.h"
 #import "XHLaunchAdConst.h"
+
+#if __has_include(<FLAnimatedImage/FLAnimatedImage.h>)
+    #import <FLAnimatedImage/FLAnimatedImage.h>
+#else
+    #import "FLAnimatedImage.h"
+#endif
 
 @implementation XHLaunchAdImageView (XHLaunchAdCache)
 - (void)xh_setImageWithURL:(nonnull NSURL *)url{

--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdView.h
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdView.h
@@ -12,15 +12,15 @@
 #import <AVKit/AVKit.h>
 
 #if __has_include(<FLAnimatedImage/FLAnimatedImage.h>)
-#import <FLAnimatedImage/FLAnimatedImage.h>
+    #import <FLAnimatedImage/FLAnimatedImage.h>
 #else
-#import "FLAnimatedImage.h"
+    #import "FLAnimatedImage.h"
 #endif
 
 #if __has_include(<FLAnimatedImage/FLAnimatedImageView.h>)
-#import <FLAnimatedImage/FLAnimatedImageView.h>
+    #import <FLAnimatedImage/FLAnimatedImageView.h>
 #else
-#import "FLAnimatedImageView.h"
+    #import "FLAnimatedImageView.h"
 #endif
 
 


### PR DESCRIPTION
当 Podfile 中添加```use_frameworks!```时，使用```#import "FLAnimatedImage.h"```会提示文件不存在