### PR TITLE
修复在 iPhone 12 系列下，跳过按钮位置不准确的问题

### DIFF
--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdButton.m
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdButton.m
@@ -36,7 +36,7 @@
     if (self) {
         
         _skipType = skipType;
-        CGFloat y = XH_FULLSCREEN ? 44 : 20;
+        CGFloat y = XH_SAFEAREAINSETS.top;
         self.frame = CGRectMake(XH_ScreenW-80,y, 70, 35);//方形
         switch (skipType) {
             case SkipTypeRoundTime:

--- a/XHLaunchAd/XHLaunchAd/XHLaunchAdConst.h
+++ b/XHLaunchAd/XHLaunchAd/XHLaunchAdConst.h
@@ -20,6 +20,7 @@
 #define XH_IPHONEXSMAX    ([UIScreen instancesRespondToSelector:@selector(currentMode)] ? CGSizeEqualToSize(CGSizeMake(1242, 2688), [[UIScreen mainScreen] currentMode].size) : NO)
 #define XH_FULLSCREEN ((XH_IPHONEX || XH_IPHONEXR || XH_IPHONEXSMAX) ? YES : NO)
 
+#define XH_SAFEAREAINSETS ((([[UIDevice currentDevice].systemVersion floatValue] >= 11) && [UIApplication sharedApplication].keyWindow.safeAreaInsets.top >= 44) ? [UIApplication sharedApplication].keyWindow.safeAreaInsets : UIEdgeInsetsMake(20, 0, 0, 0))
 
 #define XHISURLString(string)  ([string hasPrefix:@"https://"] || [string hasPrefix:@"http://"]) ? YES:NO
 #define XHStringContainsSubString(string,subString)  ([string rangeOfString:subString].location == NSNotFound) ? NO:YES


### PR DESCRIPTION
使用 safeAreaInsets 替代 固定的 XH_FULLSCREEN 判断，预防以后有新的屏幕尺寸时导致出现问题。
也能兼容不同的 状态栏高度（例如iPhone 11 的是 48，不同于通常情况下的44）